### PR TITLE
Add support for list of directories in `vhdl_autodoc_source_path`

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -10,3 +10,7 @@ Configuration options
   Determines the root of the directory structure where the VHDL source codes
   used for automatic documentation generation reside. Must be relative to from
   where the build command is run.
+
+  In case project contains directories which You do not wish to parse, the 
+  list of directories can be also provided. Parsing will be done for each one 
+  in the order defined by the list. 

--- a/doc/source/directives_detailed.rst
+++ b/doc/source/directives_detailed.rst
@@ -241,9 +241,9 @@ Auto- Directives
     Automatically generates a documentation for an entity. Has one required
     argument, the  name of the entity. For the automatic generation to work,
     the :py:attr:`vhdl_autodoc_source_path` configuration option must be set to
-    point to a valid directory containing VHDL sources describing this entity.
-    See :ref:`autodoc_usage` for further instructions on how the source code
-    must be set up.
+    point to a valid directory (or list of directories) containing VHDL sources 
+    describing this entity. See :ref:`autodoc_usage` for further instructions 
+    on how the source code must be set up.
 
     .. rst:directive:option:: noautogenerics
 
@@ -260,27 +260,28 @@ Auto- Directives
     Automatically generates a documentation for an enumeration defined type.
     Has one required argument, the name of the type. For the automatic
     generation to work, the :py:attr:`vhdl_autodoc_source_path` configuration
-    option must be set to point to a valid directory containing VHDL sources
-    describing this entity. See :ref:`autodoc_usage` for further instructions
-    on how the source code must be set up.
+    option must be set to point to a valid directory (or list of directories) 
+    containing VHDL sources describing this entity. See :ref:`autodoc_usage` 
+    for further instructions on how the source code must be set up.
 
 .. rst:directive:: vhdl:autofunction
 
     Automatically generates a documentation for a pure function.
     Has one required argument, the name of the type. For the automatic
     generation to work, the :py:attr:`vhdl_autodoc_source_path` configuration
-    option must be set to point to a valid directory containing VHDL sources
-    describing this entity. See :ref:`autodoc_usage` for further instructions
-    on how the source code must be set up.
+    option must be set to point to a valid directory (or list of directories) 
+    containing VHDL sources describing this entity. See :ref:`autodoc_usage`
+    for further instructions on how the source code must be set up.
 
 .. rst:directive:: vhdl:autogenerics
 
     Automatically generates a documentation for an entity's generics. Has one
     required argument, the name of the entity whose generics to document. For
     the automatic generation to work, the :py:attr:`vhdl_autodoc_source_path`
-    configuration option must be set to point to a valid directory containing
-    VHDL sources describing the target entity.  See  :ref:`autodoc_usage` for
-    further instruction on how the source must be set up.
+    configuration option must be set to point to a valid directory (or list 
+    of directories)  containing VHDL sources describing the target entity.  
+    See  :ref:`autodoc_usage` for further instruction on how the source 
+    must be set up.
 
 .. rst:directive:: vhdl:autoconstants
 
@@ -288,36 +289,36 @@ Auto- Directives
     Has one required argument, the name of the architecture whose constants 
     are to be documented. For the automatic generation to work, the 
     :py:attr:`vhdl_autodoc_source_path` configuration option must be set to 
-    point to a valid directory containing VHDL sources describing the target 
-    entity.  See  :ref:`autodoc_usage` for further instruction on how the 
-    source must be set up.
+    point to a valid directory (or list of directories) containing VHDL 
+    sources describing the target  entity.  See  :ref:`autodoc_usage` for 
+    further instruction on how the source must be set up.
 
 .. rst:directive:: vhdl:autopackage
 
     Automatically generates a documentation for a package. Has one required
     argument, the name of the package to document. For the automatic generation
     to work, the :py:attr:`vhdl_autodoc_source_path` configuration option must
-    be set to point to a valid directory containing VHDL sources defining the
-    target package. See :ref:`autodoc_usage` for further instructions on how
-    the source must be set up.
+    be set to point to a valid directory (or list of directories) containing 
+    VHDL sources defining the target package. See :ref:`autodoc_usage` for 
+    further instructions on how the source must be set up.
 
 .. rst:directive:: vhdl:autoports
 
     Automatically generates a documentation for an entity's ports. Has one
     required argument, the name of the entity whose ports to document. For the
     automatic generation to work, the :py:attr:`vhdl_autodoc_source_path`
-    configuration option must be set to point to a valid directory containing
-    VHDL sources describing the target entity. See :ref:`autodoc_usage` for
-    further instruction on how the source must be set up.
+    configuration option must be set to point to a valid directory (or list 
+    of directories) containing VHDL sources describing the target entity. 
+    See :ref:`autodoc_usage` for further instruction on how the source must be set up.
 
 .. rst:directive:: vhdl:autorecord
 
     Automatically generates a documentation for a record-defined type. Has one
     required argument, the name of the type to document. For the automatic
     generation to work, the :py:attr:`vhdl_autodoc_source_path` configuration
-    option must be set to point to a valid directory containing VHDL sources
-    describing the type. See :ref:`autodoc_usage` for further instructions on
-    how the source must be set up.
+    option must be set to point to a valid directory (or list of directories) 
+    containing VHDL sources describing the type. See :ref:`autodoc_usage` for 
+    further instructions on how the source must be set up.
 
 .. rst:directive:: vhdl:autotype
 
@@ -325,6 +326,6 @@ Auto- Directives
     record-defined one. Has one required argument, the name of the type to
     document. For the automatic generation to work, the
     :py:attr:`vhdl_autodoc_source_path` configuration option must be set to
-    point to a valid directory containing VHDL sources describing the type. See
-    :ref:`autodoc_usage` for further instructions on how the sources must be
-    set up.
+    point to a valid directory (or list of directories) containing VHDL sources 
+    describing the type. See :ref:`autodoc_usage` for further instructions on 
+    how the sources must be set up.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,14 @@ To setup sphinx-vhdl for your project, please edit your sphinx ``conf.py`` file 
   extensions = ['sphinxvhdl.vhdl']
   vhdl_autodoc_source_path = 'path/to/your/vhdl/sources/root'
 
+In case VHDL source files reside in two different directories, You can specify a list 
+in :py:attr:`vhdl_autodoc_source_path`
+
+.. code-block:: python
+
+  extensions = ['sphinxvhdl.vhdl']
+  vhdl_autodoc_source_path = ['path/to/your/vhdl/sources1', 'path/to/your/vhdl/sources1']
+
 See :ref:`configuration` for more information.
 
 Recognized directives

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinx-vhdl
-version = 0.2.0
+version = 0.2.1
 author = CESNET z.s.p.o.
 author_email = cabal@cesnet.cz
 description = A Sphinx domain and autodocumenter for VHDL

--- a/src/sphinxvhdl/autodoc.py
+++ b/src/sphinxvhdl/autodoc.py
@@ -48,207 +48,214 @@ class ParseState(Enum):
     ENUM = auto()
 
 
-def init(path: str) -> None:
-    for filename in (
-            glob.glob(os.path.join(path, "**", "*.vhd"), recursive=True) + glob.glob(os.path.join(path, "**", "*.vhdl"),
-                                                                                     recursive=True)):
-        with open(filename, 'r') as source_file:
-            source_code = source_file.readlines()
+def init(path) -> None:
 
-        current_doc = []
-        current_entity = '' # Name of the enetity
-        current_constant = '' # Name of the constant
-        current_group = '' # Name of the group
-        group_definition = '' # Description of group of ports or generics
-        current_package = ''
-        current_type_name = ''  # record or enum
-        state: Optional[ParseState] = None
-        group_state: Optional[ParseState] = None
-        open_parentheses = 0
-        lineno = 0
-        for line in source_code:
-            lineno += 1
-            line = line.strip()
-            line_lowercase = line.lower()
-            # Group parsing logic
-            if state == ParseState.PORT and group_state == ParseState.GENERIC:
-                current_group = ""
+    if isinstance(path, list):
+        path_list = path
+    else:
+        path_list = [path]
 
-            # Line comments logic
-            if line_lowercase.startswith('-- '):
-                # Logic for sampling names of groups of ports and generics
-                if (state == ParseState.PORT or state == ParseState.GENERIC) and '====' in line_lowercase:
-                    group_state = state
-                    state = ParseState.GROUPS
+    for dir in path_list:
+        for filename in (
+                glob.glob(os.path.join(dir, "**", "*.vhd"), recursive=True) + glob.glob(os.path.join(dir, "**", "*.vhdl"),
+                                                                                        recursive=True)):
+            with open(filename, 'r') as source_file:
+                source_code = source_file.readlines()
+
+            current_doc = []
+            current_entity = '' # Name of the enetity
+            current_constant = '' # Name of the constant
+            current_group = '' # Name of the group
+            group_definition = '' # Description of group of ports or generics
+            current_package = ''
+            current_type_name = ''  # record or enum
+            state: Optional[ParseState] = None
+            group_state: Optional[ParseState] = None
+            open_parentheses = 0
+            lineno = 0
+            for line in source_code:
+                lineno += 1
+                line = line.strip()
+                line_lowercase = line.lower()
+                # Group parsing logic
+                if state == ParseState.PORT and group_state == ParseState.GENERIC:
                     current_group = ""
-                    current_doc = []
-                elif state == ParseState.GROUPS and current_group != '' and '====' not in line_lowercase:
-                    current_doc.append(line[3:])
-                elif state == ParseState.GROUPS and '====' not in line_lowercase:
-                    current_group = current_entity + " " + line[3:].strip()
-                    current_doc = []
-                elif state == ParseState.GROUPS and '====' in line_lowercase:
-                    group_definition = current_doc
-                    groups_desc[current_group] = group_definition
-                    state = group_state
-                    current_doc = []
-                else:
-                    current_doc.append(line[3:])
 
-            # If line start with keyword architecture then save name of architecture
-            elif line_lowercase.startswith('architecture'):
-                state = ParseState.ARCH_DECL
-                current_constant = line.split()[3]
+                # Line comments logic
+                if line_lowercase.startswith('-- '):
+                    # Logic for sampling names of groups of ports and generics
+                    if (state == ParseState.PORT or state == ParseState.GENERIC) and '====' in line_lowercase:
+                        group_state = state
+                        state = ParseState.GROUPS
+                        current_group = ""
+                        current_doc = []
+                    elif state == ParseState.GROUPS and current_group != '' and '====' not in line_lowercase:
+                        current_doc.append(line[3:])
+                    elif state == ParseState.GROUPS and '====' not in line_lowercase:
+                        current_group = current_entity + " " + line[3:].strip()
+                        current_doc = []
+                    elif state == ParseState.GROUPS and '====' in line_lowercase:
+                        group_definition = current_doc
+                        groups_desc[current_group] = group_definition
+                        state = group_state
+                        current_doc = []
+                    else:
+                        current_doc.append(line[3:])
 
-            # If line contains keyword constant and state is not generice then start to collecting constants
-            elif state == ParseState.ARCH_DECL and 'constant' in line_lowercase:
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                definition = line.split('--')[0].split(';')[0]
-                if ':=' not in definition:
-                    definition += ':= UNDEFINED'
-                definition = definition[8:].strip()
-                constants[current_constant.lower()][definition] = current_doc
-                current_doc = []
+                # If line start with keyword architecture then save name of architecture
+                elif line_lowercase.startswith('architecture'):
+                    state = ParseState.ARCH_DECL
+                    current_constant = line.split()[3]
 
-            # If there is -- without gap, then ignore
-            elif line_lowercase == '--':
-                current_doc.append('')
-
-            # If there is word entity then try parse, save entity name and add description of entity to associative array
-            # ID of ass. array is name of entity. At the end clear current description and change state to entity declaration
-            elif line_lowercase.startswith('entity ') and ' is' in line_lowercase:
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                current_entity = line.split()[1]
-                entities[current_entity.lower()] = current_doc
-                current_doc = []
-                state = ParseState.ENTITY_DECL
-
-            # Check if there is any port declaration
-            elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('port'):
-                state = ParseState.PORT
-                current_doc = []
-
-            # Check if there is any generic declaration
-            elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('generic'):
-                state = ParseState.GENERIC
-                current_doc = []
-
-            # If there is line which contains ":" then it's one of ports, parse it and save his definition
-            elif state == ParseState.PORT and ':' in line_lowercase:
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                definition = line.split('--')[0].split(';')[0].split(':=')[0].strip()
-                if definition.lower().startswith('signal'):
-                    definition = definition[6:].strip()
-                if current_group == "":
-                    definition = definition
-                else:
-                    definition = current_group + "}" + definition
-
-                portsignals[current_entity.lower()][definition] = current_doc
-                current_doc = []
-
-            # If there is line which contains ":" then it's one of generic, parse it and save his definition
-            elif state == ParseState.GENERIC and ':' in line_lowercase:
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                definition = line.split('--')[0].split(';')[0].strip()
-                if ':=' not in definition:
-                    definition += ':= UNDEFINED'
-                if definition.lower().startswith('constant'):
+                # If line contains keyword constant and state is not generice then start to collecting constants
+                elif state == ParseState.ARCH_DECL and 'constant' in line_lowercase:
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    definition = line.split('--')[0].split(';')[0]
+                    if ':=' not in definition:
+                        definition += ':= UNDEFINED'
                     definition = definition[8:].strip()
-                if current_group == "":
-                    definition = definition
-                else:
-                    definition = current_group + "}" + definition
-
-                generics[current_entity.lower()][definition] = current_doc
-                current_doc = []
-
-            # End of the entity was found
-            elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('end'):
-                state = None
-                group_state = None
-                current_doc = []
-
-            # If there is magic word package then parse package and save his definition
-            elif (state is None or state is ParseState.PACKAGE) and line_lowercase.startswith('package'):
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                state = ParseState.PACKAGE
-                current_package = ('' if current_package == '' else (current_package + '.')) + line.split()[1]
-                packages[current_package.lower()] = current_doc
-                current_doc = []
-
-            # Signalization of end of the package
-            elif state is ParseState.PACKAGE and line_lowercase.startswith('end package'):
-                current_package = '.'.join(current_package.split('.')[:-1])
-                state = None if current_package == '' else ParseState.PACKAGE
-                current_doc = []
-
-            # Package contains type, parse it
-            elif (state is None or state is ParseState.PACKAGE) and line_lowercase.startswith('type'):
-                if ' record' in line.split('--')[0].lower().split(maxsplit=2)[-1]:
-                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                    records[line.split()[1]] = current_doc
-                    current_doc = []
-                    state = ParseState.RECORD
-                    current_type_name = line.split()[1]
-                elif ' '.join(line.split()[2:])[2:].strip().startswith('('):
-                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                    enums[line.split()[1]] = current_doc
-                    current_doc = []
-                    state = ParseState.ENUM
-                    current_type_name = line.split()[1]
-                else:
-                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                    types[line.split()[1]] = ' '.join(line.split()[3:]), current_doc
+                    constants[current_constant.lower()][definition] = current_doc
                     current_doc = []
 
-            # Signalization of the end of record
-            elif state is ParseState.RECORD and line_lowercase.startswith('end record'):
-                if current_package != '':
-                    state = ParseState.PACKAGE
-                else:
-                    state = None
-                current_doc = []
+                # If there is -- without gap, then ignore
+                elif line_lowercase == '--':
+                    current_doc.append('')
 
-            # Signalization of the start of record
-            elif state is ParseState.RECORD and ':' in line:
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                element_name, element_type = tuple([x.strip() for x in line.split(';')[0].split(':', 1)])
-                record_elements[current_type_name][f'{element_name} : {element_type}'] = current_doc
-                current_doc = []
-
-            # Enumarate parsing
-            elif state is ParseState.ENUM:
-                if not line_lowercase.startswith(')'):
+                # If there is word entity then try parse, save entity name and add description of entity to associative array
+                # ID of ass. array is name of entity. At the end clear current description and change state to entity declaration
+                elif line_lowercase.startswith('entity ') and ' is' in line_lowercase:
                     parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                    enumvals[current_type_name][line.split(',')[0]] = current_doc
+                    current_entity = line.split()[1]
+                    entities[current_entity.lower()] = current_doc
                     current_doc = []
-
-            # Function parsing
-            elif line_lowercase.startswith('function') and line.split('--')[0].strip().endswith(';'):
-                parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
-                return_type = '' if 'return' not in line else (line.split('return')[1].strip()[:-1] + '.')
-                functions[return_type + line_lowercase.split()[1]] = current_doc
-                current_doc = []
-
-            # Ignore others
-            else:
-                current_doc = []
-
-            # Connection between ports, generics and entity
-            if state in (ParseState.PORT, ParseState.GENERIC):
-                open_parentheses += line.split('--')[0].count('(')
-                open_parentheses -= line.split('--')[0].count(')')
-                if open_parentheses == 0:
                     state = ParseState.ENTITY_DECL
 
-            # Connection between Enumerate and current package
-            if state == ParseState.ENUM:
-                open_parentheses += line.split('--')[0].count('(')
-                open_parentheses -= line.split('--')[0].count(')')
-                if open_parentheses == 0:
+                # Check if there is any port declaration
+                elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('port'):
+                    state = ParseState.PORT
+                    current_doc = []
+
+                # Check if there is any generic declaration
+                elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('generic'):
+                    state = ParseState.GENERIC
+                    current_doc = []
+
+                # If there is line which contains ":" then it's one of ports, parse it and save his definition
+                elif state == ParseState.PORT and ':' in line_lowercase:
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    definition = line.split('--')[0].split(';')[0].split(':=')[0].strip()
+                    if definition.lower().startswith('signal'):
+                        definition = definition[6:].strip()
+                    if current_group == "":
+                        definition = definition
+                    else:
+                        definition = current_group + "}" + definition
+
+                    portsignals[current_entity.lower()][definition] = current_doc
+                    current_doc = []
+
+                # If there is line which contains ":" then it's one of generic, parse it and save his definition
+                elif state == ParseState.GENERIC and ':' in line_lowercase:
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    definition = line.split('--')[0].split(';')[0].strip()
+                    if ':=' not in definition:
+                        definition += ':= UNDEFINED'
+                    if definition.lower().startswith('constant'):
+                        definition = definition[8:].strip()
+                    if current_group == "":
+                        definition = definition
+                    else:
+                        definition = current_group + "}" + definition
+
+                    generics[current_entity.lower()][definition] = current_doc
+                    current_doc = []
+
+                # End of the entity was found
+                elif state == ParseState.ENTITY_DECL and line_lowercase.startswith('end'):
+                    state = None
+                    group_state = None
+                    current_doc = []
+
+                # If there is magic word package then parse package and save his definition
+                elif (state is None or state is ParseState.PACKAGE) and line_lowercase.startswith('package'):
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    state = ParseState.PACKAGE
+                    current_package = ('' if current_package == '' else (current_package + '.')) + line.split()[1]
+                    packages[current_package.lower()] = current_doc
+                    current_doc = []
+
+                # Signalization of end of the package
+                elif state is ParseState.PACKAGE and line_lowercase.startswith('end package'):
+                    current_package = '.'.join(current_package.split('.')[:-1])
+                    state = None if current_package == '' else ParseState.PACKAGE
+                    current_doc = []
+
+                # Package contains type, parse it
+                elif (state is None or state is ParseState.PACKAGE) and line_lowercase.startswith('type'):
+                    if ' record' in line.split('--')[0].lower().split(maxsplit=2)[-1]:
+                        parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                        records[line.split()[1]] = current_doc
+                        current_doc = []
+                        state = ParseState.RECORD
+                        current_type_name = line.split()[1]
+                    elif ' '.join(line.split()[2:])[2:].strip().startswith('('):
+                        parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                        enums[line.split()[1]] = current_doc
+                        current_doc = []
+                        state = ParseState.ENUM
+                        current_type_name = line.split()[1]
+                    else:
+                        parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                        types[line.split()[1]] = ' '.join(line.split()[3:]), current_doc
+                        current_doc = []
+
+                # Signalization of the end of record
+                elif state is ParseState.RECORD and line_lowercase.startswith('end record'):
                     if current_package != '':
                         state = ParseState.PACKAGE
                     else:
                         state = None
+                    current_doc = []
+
+                # Signalization of the start of record
+                elif state is ParseState.RECORD and ':' in line:
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    element_name, element_type = tuple([x.strip() for x in line.split(';')[0].split(':', 1)])
+                    record_elements[current_type_name][f'{element_name} : {element_type}'] = current_doc
+                    current_doc = []
+
+                # Enumarate parsing
+                elif state is ParseState.ENUM:
+                    if not line_lowercase.startswith(')'):
+                        parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                        enumvals[current_type_name][line.split(',')[0]] = current_doc
+                        current_doc = []
+
+                # Function parsing
+                elif line_lowercase.startswith('function') and line.split('--')[0].strip().endswith(';'):
+                    parse_inline_doc_or_print_error(current_doc, filename, line, lineno)
+                    return_type = '' if 'return' not in line else (line.split('return')[1].strip()[:-1] + '.')
+                    functions[return_type + line_lowercase.split()[1]] = current_doc
+                    current_doc = []
+
+                # Ignore others
+                else:
+                    current_doc = []
+
+                # Connection between ports, generics and entity
+                if state in (ParseState.PORT, ParseState.GENERIC):
+                    open_parentheses += line.split('--')[0].count('(')
+                    open_parentheses -= line.split('--')[0].count(')')
+                    if open_parentheses == 0:
+                        state = ParseState.ENTITY_DECL
+
+                # Connection between Enumerate and current package
+                if state == ParseState.ENUM:
+                    open_parentheses += line.split('--')[0].count('(')
+                    open_parentheses -= line.split('--')[0].count(')')
+                    if open_parentheses == 0:
+                        if current_package != '':
+                            state = ParseState.PACKAGE
+                        else:
+                            state = None
 

--- a/src/sphinxvhdl/vhdl.py
+++ b/src/sphinxvhdl/vhdl.py
@@ -611,7 +611,7 @@ class VHDLDomain(Domain):
 
 def setup(app: Sphinx):
     app.add_domain(VHDLDomain)
-    app.add_config_value('vhdl_autodoc_source_path', '.', 'env', [str])
+    app.add_config_value('vhdl_autodoc_source_path', '.', 'env', [str, list])
     logger.verbose('The sphinx-vhdl extension has been activated.')
 
     return {


### PR DESCRIPTION
This PR adds a suport for providing list of directories for VHDL source files in `vhdl_autodoc_source_path`.
The proposed solution is backward compatible , i.e. it will not break dependencies in old project as the implemented solution 
checks what type of `vhdl_autodoc_source_path` prior to looping through list elements (string will be converted to list of size 1)